### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/api


### PR DESCRIPTION
We're currently going through and adding/updating CODEOWNERS for every @planningcenter repo.

These initial PRs (of which this PR is one) should hopefully be straightforward. The main goal of this effort is to capture the state of the world as it is now, and iterate in the future as pain points are felt and code owners are identified.