### PR TITLE
chore/security: remove incorrect documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # PCO API Wrapper for Node
 
-## Installation
-
-```
-yarn add pco_api
-```
-
 ## Usage
 
 ```


### PR DESCRIPTION
`pco_api` is not a Node package, so don't tell people to install it. An attacker could register `pco_api` to install a malicious payload, and that would be bad times.